### PR TITLE
Serialize ''(empty) string to empty database value

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -31,12 +31,10 @@ class JSONFormFieldBase(object):
         return value
 
     def clean(self, value):
-
         if not value and not self.required:
+            if value == '':
+                return ''
             return None
-
-        if value == '':
-            return ''
 
         # Trap cleaning errors & bubble them up as JSON errors
         try:

--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -70,6 +70,8 @@ class JSONFieldBase(six.with_metaclass(SubfieldBase, models.Field)):
             # checking if it's empty. This is a special case for South datamigrations
             # see: https://github.com/bradjasper/django-jsonfield/issues/52
             if not hasattr(obj, "pk") or obj.pk is not None:
+                if value == '':
+                    return ''
                 if isinstance(value, six.string_types):
                     try:
                         return json.loads(value, **self.load_kwargs)
@@ -87,6 +89,8 @@ class JSONFieldBase(six.with_metaclass(SubfieldBase, models.Field)):
         """Convert JSON object to a string"""
         if self.null and value is None:
             return None
+        if value == '':
+            return ''
         return json.dumps(value, **self.dump_kwargs)
 
     def value_to_string(self, obj):
@@ -97,6 +101,8 @@ class JSONFieldBase(six.with_metaclass(SubfieldBase, models.Field)):
         value = super(JSONFieldBase, self).value_from_object(obj)
         if self.null and value is None:
             return None
+        if value == '':
+            return ''
         return self.dumps_for_display(value)
 
     def dumps_for_display(self, value):

--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -22,6 +22,8 @@ class JSONFormFieldBase(object):
 
     def to_python(self, value):
         if isinstance(value, six.string_types):
+            if value == '':
+                return ''
             try:
                 return json.loads(value, **self.load_kwargs)
             except ValueError:
@@ -32,6 +34,9 @@ class JSONFormFieldBase(object):
 
         if not value and not self.required:
             return None
+
+        if value == '':
+            return ''
 
         # Trap cleaning errors & bubble them up as JSON errors
         try:


### PR DESCRIPTION
Uses ""(empty) string in database to store empty json ([]).

You can use empty value as default for your table fields.
You will have no overhead in database if you have no data.
