### PR TITLE
Adds customizable validation messages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ It silently takes care of serialization. To use, simply add the field to one of 
 
 Python 3 & Django 1.7 supported!
 
-**Use PostgreSQL?** 1.0.0 introduced a breaking change to the underlying data type, so if you were using < 1.0.0 please see before upgrading https://github.com/bradjasper/django-jsonfield/issues/57
+**Use PostgreSQL?** 1.0.0 introduced a breaking change to the underlying data type, so if you were using < 1.0.0 please read https://github.com/bradjasper/django-jsonfield/issues/57 before upgrading.
 
 Install
 -------

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,9 @@
-django-jsonfield
-----------------
+django-nged-jsonfield
+---------------------
+
+This fork is a combination of https://github.com/Nuevosmedios/django-jsonfield and https://github.com/bradjasper/django-jsonfield .
+
+The Nuevosmedios fork provides validation of a blank field better than the original bradjasper version.
 
 django-jsonfield is a reusable Django field that allows you to store validated JSON in your model.
 

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ If you need to use your JSON field in an index or other constraint, you can use 
 Compatibility
 --------------
 
-django-jsonfield supports Python 2.7-Python 3.3 and Django 1.4+
+django-jsonfield supports Python 2.7 to Python 3.4 and Django 1.4 to 1.7
 
 **Why doesn't it support Python 2.6?**
 

--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -21,32 +21,31 @@ except ImportError:
 from .subclassing import SubfieldBase
 
 
-class JSONFormFieldBase(object):
+class JSONFormFieldBase(fields.CharField):
+    default_error_messages = {
+        'invalid': _('Enter valid JSON.'),
+    }
 
     def to_python(self, value):
         if isinstance(value, six.string_types):
             try:
                 return json.loads(value, **self.load_kwargs)
             except ValueError:
-                raise ValidationError(_("Enter valid JSON"))
+                raise ValidationError(self.error_messages['invalid'], code='invalid')
         return value
 
     def clean(self, value):
-
-        if not value and not self.required:
-            return None
-
-        # Trap cleaning errors & bubble them up as JSON errors
-        try:
-            return super(JSONFormFieldBase, self).clean(value)
-        except TypeError:
-            raise ValidationError(_("Enter valid JSON"))
+        self.validate(value)  # Checks for required
+        value = self.to_python(value)
+        self.run_validators(value)
+        return value
 
 
-class JSONFormField(JSONFormFieldBase, fields.CharField):
+class JSONFormField(JSONFormFieldBase):
     pass
 
-class JSONCharFormField(JSONFormFieldBase, fields.CharField):
+
+class JSONCharFormField(JSONFormFieldBase):
     pass
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,14 +22,14 @@ class TestCommand(Command):
             django.setup()
         call_command('test', 'jsonfield')
 
-setup(name='jsonfield',
+setup(name='nged-jsonfield',
     version='1.0.3',
     packages=['jsonfield'],
     license='MIT',
     include_package_data=True,
     author='Brad Jasper',
     author_email='bjasper@gmail.com',
-    url='https://github.com/bradjasper/django-jsonfield/',
+    url='https://github.com/Natgeoed/django-nged-jsonfield/',
     description='A reusable Django field that allows you to store validated JSON in your model.',
     long_description=open("README.rst").read(),
     install_requires=['Django >= 1.4.3'],


### PR DESCRIPTION
Hardcoding the validation message makes it difficult to customize. It also overrides the required validation message.

I've modified the `clean()` method to mimic the default clean method, except that it doesn't call `to_python()` until after the initial `validate()` call.

The validation message is moved to `default_error_messages` under the code `invalid`.
