### PR TITLE
Made package installable using ``pip``.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,9 @@ class TestCommand(Command):
         call_command('test', 'jsonfield')
 
 setup(name='jsonfield',
-    version='1.0.2',
+    version='1.0.3a',
     packages=['jsonfield'],
+    include_package_data=True, 
     license='MIT',
     author='Brad Jasper',
     author_email='bjasper@gmail.com',


### PR DESCRIPTION
Couldn't install using ``pip`` due to missing README. 

Added ``include_package_data=True`` to setup.py.

I took the liberty to pump the version to 1.0.3a to be able to test the app with our PyPI mirror. 