### PR TITLE
Fix  "'total_seconds' is not defined" when trying to serialize a timedelta

### DIFF
--- a/jsonfield/encoder.py
+++ b/jsonfield/encoder.py
@@ -38,7 +38,7 @@ class JSONEncoder(json.JSONEncoder):
                 representation = representation[:12]
             return representation
         elif isinstance(obj, datetime.timedelta):
-            return six.text_type(total_seconds(obj))
+            return six.text_type(obj.total_seconds())
         elif isinstance(obj, decimal.Decimal):
             # Serializers will coerce decimals to strings by default.
             return float(obj)


### PR DESCRIPTION
I have a NameError: global name 'total_seconds' is not defined when trying to serializing a timedelta

exemple:
```
>>> from jsonfield.encoder import JSONEncoder
>>> import datetime
>>> dict = { "timedelta": datetime.timedelta(days=2) }
>>> j =JSONEncoder()
>>> j.encode(dict)
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/usr/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
  File "/home/.../.virtualenvs/.../local/lib/python2.7/site-packages/jsonfield/encoder.py", line 41, in default
    return six.text_type(total_seconds(obj))
NameError: global name 'total_seconds' is not defined
```