### PR TITLE
"json.loads" need to support Control characters(ex. \n, \r, \t) insid…

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -26,7 +26,7 @@ class JSONFormFieldBase(object):
     def to_python(self, value):
         if isinstance(value, six.string_types):
             try:
-                return json.loads(value, **self.load_kwargs)
+                return json.loads(value, strict=False, **self.load_kwargs)
             except ValueError:
                 raise ValidationError(_("Enter valid JSON"))
         return value
@@ -76,7 +76,7 @@ class JSONFieldBase(six.with_metaclass(SubfieldBase, models.Field)):
                 if getattr(obj, "pk", None) is not None:
                     if isinstance(value, six.string_types):
                         try:
-                            return json.loads(value, **self.load_kwargs)
+                            return json.loads(value, strict=False, **self.load_kwargs)
                         except ValueError:
                             raise ValidationError(_("Enter valid JSON"))
 


### PR DESCRIPTION
When json.loads, it fails because of control characters(ex.\n, \r, \t)

Official json string support control characters. (http://json.org/)
