### PR TITLE
add try/except block for 'util' import

### DIFF
--- a/jsonfield/tests.py
+++ b/jsonfield/tests.py
@@ -9,7 +9,10 @@ except ImportError:
     from django.utils import simplejson as json
 
 from .fields import JSONField, JSONCharField
-from django.forms.util import ValidationError
+try:
+    from django.forms.utils import ValidationError
+except ImportError:
+    from django.forms.util import ValidationError
 
 from collections import OrderedDict
 


### PR DESCRIPTION
Following from #132, I have added a `try/except` which removes the `RemovedInDjango19Warning` warning.