### PR TITLE
dict value in JSONFormField

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -45,6 +45,9 @@ class JSONFormFieldBase(object):
         except TypeError:
             raise ValidationError(_("Enter valid JSON"))
 
+    def prepare_value(self, value):
+        return value if isinstance(value, six.string_types) else fields.JSONField().dumps_for_display(value)
+
 
 class JSONFormField(JSONFormFieldBase, fields.CharField):
     pass


### PR DESCRIPTION
when it has an object value, it should represent a string value
if its value is {'foo': 'bar'}, its representations must be {"foo": "bar"} instead of {'foo': 'bar'}
