### PR TITLE
Adjust JSONField for Django >=1.8

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -18,6 +18,7 @@ try:
 except ImportError:
     from django.forms.util import ValidationError
 
+from .subclassing import SubfieldBase
 from .encoder import JSONEncoder
 
 
@@ -97,7 +98,7 @@ class JSONFieldBase(JSONFieldBaseField):
             pass
 
         return value
-        
+
     def from_db_value(self, value, expression, connection, context):
         return self.to_python(value)
 


### PR DESCRIPTION
Removes deprecated SubfieldBase
Adds from_db_value (which just calls to_python)
Prevents the warning in Django 1.9 "RemovedInDjango110Warning: SubfieldBase has been deprecated. Use Field.from_db_value instead."
