### PR TITLE
Return decimal type as string

### DIFF
--- a/jsonfield/encoder.py
+++ b/jsonfield/encoder.py
@@ -40,7 +40,7 @@ class JSONEncoder(json.JSONEncoder):
             return six.text_type(obj.total_seconds())
         elif isinstance(obj, decimal.Decimal):
             # Serializers will coerce decimals to strings by default.
-            return float(obj)
+            return str(obj)
         elif isinstance(obj, uuid.UUID):
             return six.text_type(obj)
         elif isinstance(obj, QuerySet):


### PR DESCRIPTION
If you have a decimal with multiple trailing zeros, e.g. 2 for monetary fields or more, they are currently truncated to 1 precision point due to the float conversion. Since the encoding returns a string type anyway, and the conditional statement checks for decimal type, we can safely convert to string type here.