### PR TITLE
fix: allow empty string in to_python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,8 @@ Email: `contact@bradjasper.com`_
 Changes
 -------
 
+v2.0.1, 3/2/2017 -- Fixed to_python to allow for empty string
+
 v2.0.0, 2/28/2017 -- Remove support for Django versions older than 1.8
 
 v1.0.3, 2/23/2015 -- Added fix to setup.py to allow PIP install

--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -27,7 +27,7 @@ class JSONFormFieldBase(object):
         super(JSONFormFieldBase, self).__init__(*args, **kwargs)
 
     def to_python(self, value):
-        if isinstance(value, six.string_types):
+        if isinstance(value, six.string_types) and value:
             try:
                 return json.loads(value, **self.load_kwargs)
             except ValueError:

--- a/jsonfield/tests.py
+++ b/jsonfield/tests.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 import django
+from django import forms
 from django.core.serializers import deserialize, serialize
 from django.core.serializers.base import DeserializationError
 from django.db import models
@@ -288,3 +289,23 @@ class OrderedDictSerializationTest(TestCase):
         self.assertEqual(list(mod.json.keys()), self.expected_key_order)
         mod_from_db = OrderedJsonModel.objects.get(id=mod.id)
         self.assertEqual(list(mod_from_db.json.keys()), self.expected_key_order)
+
+
+class JsonNotRequiredModel(models.Model):
+    json = JSONField(blank=True, null=True)
+
+
+class JsonNotRequiredForm(forms.ModelForm):
+    class Meta:
+        model = JsonNotRequiredModel
+        fields = '__all__'
+
+
+class JsonModelFormTest(TestCase):
+    def test_blank_form(self):
+        form = JsonNotRequiredForm(data={'json': ''})
+        self.assertFalse(form.has_changed())
+
+    def test_form_with_data(self):
+        form = JsonNotRequiredForm(data={'json': '{}'})
+        self.assertTrue(form.has_changed())


### PR DESCRIPTION
`form.has_changed` is used in the formset to detect which extra forms have be modified for example. So submitting a formset with empty extra forms including JsonFields would break. This PR fixes that.

I also included a changelog entry if you are willing to do a quick release.